### PR TITLE
Enable SSL verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
  - Add access hosts to database management (#13)
+ - Enabled SSL verification (#14)
 
 ## [0.1.2] - 2016-01-31
 ### Added

--- a/src/DirectAdmin/DirectAdmin.php
+++ b/src/DirectAdmin/DirectAdmin.php
@@ -101,8 +101,6 @@ class DirectAdmin
         $this->connection = new Client([
             'base_uri' => $this->baseUrl,
             'auth' => [$username, $password],
-            'http_errors' => true,
-            'verify' => false
         ]);
     }
 


### PR DESCRIPTION
SSL verification should be enabled to prevent MITM attacks.

Also, the `http_errors` defaults to `true` so can be removed.
