### PR TITLE
Fixed PHPUnit tests, added 2 Mailbox getters

### DIFF
--- a/src/DirectAdmin/Objects/Email/Mailbox.php
+++ b/src/DirectAdmin/Objects/Email/Mailbox.php
@@ -111,6 +111,27 @@ class Mailbox extends MailObject
     }
 
     /**
+     * Return the maximum number of mails that can be send each day
+     *
+     * @return int
+     */
+    public function getMailLimit()
+    {
+        return intval($this->getData('limit'));
+    }
+
+    /**
+     * Returns if the mailbox is suspended or not
+     *
+     * @return bool
+     */
+    public function getMailSuspended()
+    {
+        return( strcasecmp($this->getData('suspended'),"yes" ) == 0 );
+    }
+
+
+    /**
      * Cache wrapper to keep mailbox stats up to date.
      *
      * @param string $key
@@ -123,6 +144,7 @@ class Mailbox extends MailObject
                 'domain' => $this->getDomainName(),
                 'action' => 'full_list',
             ]);
+
             return \GuzzleHttp\Psr7\parse_query($result[$this->getPrefix()]);
         });
     }

--- a/tests/DirectAdmin/UserTest.php
+++ b/tests/DirectAdmin/UserTest.php
@@ -226,15 +226,17 @@ class UserTest extends \PHPUnit\Framework\TestCase
         // Create 2 forwarders after asserting they are the first
         $this->assertEmpty($domain->getMailboxes());
         $mail1 = $domain->createMailbox('mail1', generateTemporaryPassword());
-        $mail2 = $domain->createMailbox('mail2', generateTemporaryPassword(), 500, 500);
+        $mail2 = $domain->createMailbox('mail2', generateTemporaryPassword(), 500, 50);
         $this->assertCount(2, $boxes = $domain->getMailboxes());
 
         // Check mailbox statistics
         $this->assertEquals('mail1@' . TEST_USER_DOMAIN, $boxes['mail1']->getEmailAddress());
-        $this->assertNull($mail1->getDiskLimit());
+        $this->assertNull( $mail1->getDiskLimit() );
         $this->assertEquals(500, $mail2->getDiskLimit());
         $this->assertEquals(0, $mail1->getDiskUsage(), 'Disk usage should be near empty', 0.1);
         $this->assertEquals(0, $mail2->getMailsSent());
+        $this->assertEquals(50, $mail2->getMailLimit());
+        $this->assertFalse( $mail2->getMailSuspended() );
 
         // Changing password should not throw any errors
         $mail1->setPassword(generateTemporaryPassword());


### PR DESCRIPTION
I've changed the PHPUnit tests by adding a few assertions and moving the testDeleteAccounts test to the end of the list of tests.

Also changed the used mail limit (per day) to 50 in the mailbox test. Added getMailLimit and getMailSuspended functions. Also included PHPunit tests for these functions.